### PR TITLE
.gitignore: Ignore PDFs by default (force add with 'git add -f')

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore compiled PDFs (if you want to add a pdf, use `git add -f path/to/my.pdf`)
+*.pdf


### PR DESCRIPTION
Ignore PDFs by default. This will save us huge binary diffs - we can just upload them when we want them instead of every time.
