### PR TITLE
Add tools for real-time audio sampling and classifying

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Ignore compiled PDFs (if you want to add a pdf, use `git add -f path/to/my.pdf`)
 *.pdf
 
+# Ignore model checkpoints
+Code/ckpt
+
 # Don't upload the whole dataset to the repo
 PodcastFillers
 *.zip

--- a/Code/audio_utils.py
+++ b/Code/audio_utils.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python3
 
+import asyncio
 import sounddevice as sd
 # See https://python-sounddevice.readthedocs.io/en/0.5.1/usage.html#callback-streams for info
 # on real-time recording & playback
@@ -19,5 +20,38 @@ def downsample(audio, sample_rate, new_sample_rate):
     pass
 
 def convert_to_tensors(audio, sample_rate, shape):
-    '''Convert input audio to tensors of the desired shape. Returns a list of tensors'''
+    '''Convert input audio (arbitrary length) to tensors of the desired shape. Returns a list of tensors'''
     pass
+
+async def audiostream(channels=1, **kwargs):
+    '''Generator yielding blocks of input audio data'''
+    q_in = asyncio.Queue()
+    loop = asyncio.get_event_loop()
+
+    def callback(data, frame_count, time_info, status):
+        loop.call_soon_threadsafe(q_in.put_nowait, (data.copy(), status))
+
+    stream = sd.InputStream(callback=callback, channels=channels, **kwargs)
+    with stream:
+        while True:
+            data, status = await q_in.get()
+            yield data, status
+
+async def sample_audiostream(**kwargs):
+    '''Asynchronous task to sample data from an audiostream'''
+    async for data, status in audiostream(**kwargs):
+        if status:
+            print(status)
+        print('min:', data.min(), '\tmax:', data.max())
+
+if __name__ == "__main__":
+    async def main():
+        try:
+            await asyncio.wait_for(sample_audiostream(), timeout=2)
+        except asyncio.TimeoutError:
+            pass
+
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        sys.exit('\nInterrupted by user')

--- a/Code/audio_utils.py
+++ b/Code/audio_utils.py
@@ -1,23 +1,10 @@
 #! /usr/bin/env python3
 
-from FillerDetector import FillerDetector
 import asyncio
 import sounddevice as sd
 # See https://python-sounddevice.readthedocs.io/en/0.5.1/usage.html#callback-streams for info
 # on real-time recording & playback
 import torch
-
-def record(audio_device, duration):
-    '''Record audio from audio_device for duration. Returns audio, sample_rate'''
-    pass
-
-def read(audio_file):
-    '''Read audio from a file. Returns audio, sample_rate'''
-    pass
-
-def convert_to_tensors(audio, sample_rate, shape):
-    '''Convert input audio of arbitrary length to tensors of the desired shape. Returns a list of tensors'''
-    pass
 
 async def audiostream(channels=1, **kwargs):
     '''Generator yielding blocks of input audio data'''
@@ -32,34 +19,3 @@ async def audiostream(channels=1, **kwargs):
         while True:
             data, status = await q_in.get()
             yield data, status
-
-async def sample_audiostream(**kwargs):
-    '''Asynchronous task to sample data from an audiostream'''
-    async for data, status in audiostream(**kwargs):
-        if status:
-            print(status)
-        print(data.shape)
-
-async def classify_audiostream(classifier, torch_device, **kwargs):
-    '''Asynchronous task to sample & classify audiostream data as it arrives'''
-    async for audio, _ in audiostream(**kwargs):
-        data = torch.unsqueeze(torch.flatten(torch.from_numpy(audio)), 0)
-        outputs = classifier(data.to(torch_device))
-        print(outputs)
-
-if __name__ == "__main__":
-    classifier = FillerDetector()
-    classifier.load_state_dict(torch.load('ckpt/f0.838.ckpt/model.pt', weights_only=True))
-    torch_device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-    classifier.to(torch_device)
-
-    async def main():
-        try:
-            await asyncio.wait_for(classify_audiostream(classifier, torch_device, blocksize=16000, samplerate=16000), timeout=10)
-        except asyncio.TimeoutError:
-            pass
-
-    try:
-        asyncio.run(main())
-    except KeyboardInterrupt:
-        sys.exit('\nInterrupted by user')

--- a/Code/audio_utils.py
+++ b/Code/audio_utils.py
@@ -1,0 +1,23 @@
+#! /usr/bin/env python3
+
+import sounddevice as sd
+# See https://python-sounddevice.readthedocs.io/en/0.5.1/usage.html#callback-streams for info
+# on real-time recording & playback
+# Maybe we can use a Stream callback to produce 1-second chunks of audio?
+# See also https://python-sounddevice.readthedocs.io/en/0.5.1/examples.html#plot-microphone-signal-s-in-real-time
+
+def record(audio_device, duration):
+    '''Record audio from audio_device for duration. Returns audio, sample_rate'''
+    pass
+
+def read(audio_file):
+    '''Read audio from a file. Returns audio, sample_rate'''
+    pass
+
+def downsample(audio, sample_rate, new_sample_rate):
+    '''Downsample audio to a new sample rate'''
+    pass
+
+def convert_to_tensors(audio, sample_rate, shape):
+    '''Convert input audio to tensors of the desired shape. Returns a list of tensors'''
+    pass

--- a/Code/bertha.py
+++ b/Code/bertha.py
@@ -1,0 +1,33 @@
+#! /usr/bin/env python3
+
+from FillerDetector import FillerDetector
+from audio_utils import audiostream
+import asyncio
+import sys
+import torch
+
+async def classify_audiostream(classifier, torch_device, **kwargs):
+    '''Asynchronous task to sample & classify audiostream data as it arrives'''
+    async for audio, _ in audiostream(**kwargs):
+        data = torch.unsqueeze(torch.flatten(torch.from_numpy(audio)), 0)
+        outputs = classifier(data.to(torch_device))
+        is_filler = outputs[0][1] > outputs[0][0]
+        print(f'is_filler: {is_filler}')
+
+if __name__ == "__main__":
+    classifier = FillerDetector()
+    classifier.load_state_dict(torch.load('ckpt/f0.840.ckpt/model.pt', weights_only=True))
+    torch_device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    classifier.to(torch_device)
+
+    async def classify_loop(timeout):
+        try:
+            await asyncio.wait_for(classify_audiostream(classifier, torch_device, blocksize=16000, samplerate=16000), timeout=timeout)
+        except asyncio.TimeoutError:
+            pass
+
+    timeout = int(sys.argv[1]) if len(sys.argv) > 1 else 100
+    try:
+        asyncio.run(classify_loop(timeout))
+    except KeyboardInterrupt:
+        sys.exit('\nInterrupted by user')


### PR DESCRIPTION
The main sample & classify loop is in bertha.py. Run it with e.g. `python3 bertha.py 100` to sample for 100 seconds, or put in whatever number you want to sample for a different amount of time.

I haven't yet tried to run this on my laptop. That's the next step, I think.